### PR TITLE
Green Dye recipe now yields 2 Green Dye

### DIFF
--- a/src/main/resources/data/pitg/recipes/green_dye.json
+++ b/src/main/resources/data/pitg/recipes/green_dye.json
@@ -10,6 +10,7 @@
     }
   ],
   "result": {
-    "item": "pitg:green_dye"
+    "item": "pitg:green_dye",
+    "count": 2
   }
 }


### PR DESCRIPTION
Since there this recipe requires 2 dyes to make, it makes sense for the output to also be 2, to follow Vanilla's pattern.